### PR TITLE
Use cl-lib macro instead of cl.el

### DIFF
--- a/apiwrap.el
+++ b/apiwrap.el
@@ -32,6 +32,8 @@
 
 ;;; Code:
 
+(require 'cl-lib)
+
 (defun apiwrap-resolve-api-params (object url &optional noencode)
   "Resolve parameters in URL to values in OBJECT.
 
@@ -273,16 +275,16 @@ for the resource (e.g., for posting)."
     (error "invalid link function"))
 
   `(prog1 ,service-name
-     ,@(loop for method in `((get . ,get-func) (put . ,put-func) (head . ,head-func)
-                             (post . ,post-func) (patch . ,patch-func) (delete . ,delete-func))
-             collect
-             (let ((symbol (intern (concat prefix "-def" (symbol-name (car method))))))
-               `(defmacro ,symbol (resource doc version link &optional object internal-resource)
-                  ,(apiwrap--defmethod-doc service-name (car method))
-                  (declare (indent defun) (doc-string 2))
-                  (apiwrap--defresource ,prefix ',(car method) ',(cdr method)
-                    ,link-func ',standard-parameters resource doc version link
-                    object internal-resource))))))
+     ,@(cl-loop for method in `((get . ,get-func) (put . ,put-func) (head . ,head-func)
+                                (post . ,post-func) (patch . ,patch-func) (delete . ,delete-func))
+                collect
+                (let ((symbol (intern (concat prefix "-def" (symbol-name (car method))))))
+                  `(defmacro ,symbol (resource doc version link &optional object internal-resource)
+                     ,(apiwrap--defmethod-doc service-name (car method))
+                     (declare (indent defun) (doc-string 2))
+                     (apiwrap--defresource ,prefix ',(car method) ',(cdr method)
+                                           ,link-func ',standard-parameters resource doc version link
+                                           object internal-resource))))))
 
 (provide 'apiwrap)
 ;;; apiwrap.el ends here


### PR DESCRIPTION
There are following warnings.

```
In apiwrap-new-backend:
apiwrap.el:276:14:Warning: reference to free variable ‘for’
apiwrap.el:276:18:Warning: reference to free variable ‘method’
apiwrap.el:276:25:Warning: reference to free variable ‘in’
apiwrap.el:278:14:Warning: reference to free variable ‘collect’

In end of data:
apiwrap.el:289:1:Warning: the function ‘loop’ is not known to be defined.
```