### PR TITLE
Rewrite apiwrap-plist->alist with cl-loop to get list keywords in the same order

### DIFF
--- a/apiwrap.el
+++ b/apiwrap.el
@@ -92,11 +92,11 @@ symbol `keyword'."
     (error "Bad plist"))
   (cl-loop for (k v) on plist by #'cddr collect (cons (apiwrap--kw->sym k) v)))
 
-(defun apiwrap--kw->sym (kw)
-  "Convert a keyword to a symbol."
-  (if (keywordp kw)
-      (intern (substring (symbol-name kw) 1))
-    kw))
+(defun apiwrap--kw->sym (keyword)
+  "Convert a KEYWORD to a symbol."
+  (if (keywordp keyword)
+      (intern (substring (symbol-name keyword) 1))
+    keyword))
 
 (defun apiwrap--docfn (service-name doc object-param-doc method external-resource link)
   "Documentation string for resource-wrapping functions created

--- a/apiwrap.el
+++ b/apiwrap.el
@@ -345,7 +345,7 @@ Otherwise, just return VALUE quoted."
 (defmacro apiwrap-new-backend (name prefix standard-parameters &rest config)
   "Define a new API backend.
 
-SERVICE-NAME is the name of the service this backend will wrap.
+NAME is the name of the service this backend will wrap.
 It will be used in docstrings of the primitive method macros.
 
 PREFIX is the prefix to use for the macros and for the

--- a/apiwrap.el
+++ b/apiwrap.el
@@ -89,14 +89,8 @@ Example:
 If a PLIST key is a `:keyword', then it is converted into a
 symbol `keyword'."
   (when (= 1 (mod (length plist) 2))
-    (error "bad plist"))
-  (let (alist)
-    (while plist
-      (push (cons (apiwrap--kw->sym (car plist))
-                  (cadr plist))
-            alist)
-      (setq plist (cddr plist)))
-    alist))
+    (error "Bad plist"))
+  (cl-loop for (k v) on plist by #'cddr collect (cons (apiwrap--kw->sym k) v)))
 
 (defun apiwrap--kw->sym (kw)
   "Convert a keyword to a symbol."


### PR DESCRIPTION
I no longer remember why I needed this, but it should make the function less surprising to use.